### PR TITLE
Bump version to 0.1.33 and add spreadsheet file upload stories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "axios": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",

--- a/src/components/DropZone/__stories__/DropZone.stories.ts
+++ b/src/components/DropZone/__stories__/DropZone.stories.ts
@@ -408,7 +408,7 @@ const meta = {
     },
     allowedFileTypes: {
       control: 'select',
-      options: ['images', 'video', 'text'],
+      options: ['images', 'video', 'text', 'spreadsheet'],
       description: 'Types of files allowed to be uploaded',
     },
     multiple: {
@@ -599,6 +599,43 @@ export const MultipleTextWithFileList: Story = {
     displayPreview: false,
     displayFileList: true,
     label: 'Upload multiple text files (TXT, CSV)',
+  },
+};
+
+// Spreadsheet variants
+export const SingleSpreadsheetWithFileList: Story = {
+  render: (args) => ({
+    components: { DropZoneWrapper },
+    setup() {
+      return { args };
+    },
+    template: '<DropZoneWrapper v-bind="args" />',
+  }),
+  args: {
+    instanceName: 'single-spreadsheet-dropzone',
+    allowedFileTypes: 'spreadsheet',
+    multiple: false,
+    displayPreview: false,
+    displayFileList: true,
+    label: 'Upload a single spreadsheet file (XLS, XLSX)',
+  },
+};
+
+export const MultipleSpreadsheetWithFileList: Story = {
+  render: (args) => ({
+    components: { DropZoneWrapper },
+    setup() {
+      return { args };
+    },
+    template: '<DropZoneWrapper v-bind="args" />',
+  }),
+  args: {
+    instanceName: 'multiple-spreadsheet-dropzone',
+    allowedFileTypes: 'spreadsheet',
+    multiple: true,
+    displayPreview: false,
+    displayFileList: true,
+    label: 'Upload multiple spreadsheet files (XLS, XLSX)',
   },
 };
 


### PR DESCRIPTION
Update the package version to 0.1.33 and introduce new stories for uploading spreadsheet files in the DropZone component. The allowed file types now include spreadsheets.