### PR TITLE
version 0.1.32 (#30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "axios": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,11 +28,16 @@ export const ALLOWED_TYPES_MAP: Record<
     types: ['csv'],
     prefix: 'text',
   },
+  spreadsheet: {
+    types: ['xls', 'xlsx'],
+    prefix: 'application',
+  },
 };
 
 export const IMAGE_TYPES = ALLOWED_TYPES_MAP.images.types;
 export const VIDEO_TYPES = ALLOWED_TYPES_MAP.video.types;
 export const TEXT_TYPES = ALLOWED_TYPES_MAP.text.types;
+export const SPREADSHEET_TYPES = ALLOWED_TYPES_MAP.spreadsheet.types;
 
 export const ALLOWED_MIME_TYPES: Record<AllowedFileTypes, string> =
   Object.entries(ALLOWED_TYPES_MAP).reduce(

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -232,7 +232,7 @@ export type LoadImageTypeFunction = (
   computedImageSrc: { value: string | undefined },
 ) => Promise<void>;
 
-export type AllowedFileTypes = 'images' | 'video' | 'text';
+export type AllowedFileTypes = 'images' | 'video' | 'text' | 'spreadsheet';
 
 export type DropZoneProps = {
   instanceName: string;


### PR DESCRIPTION
* Bump version to 0.1.30 and remove unnecessary close tag in Select component (#24)

* Add negative number validation to TextInput component (#26)

* Add negative number validation to TextInput component

* Bump version to 0.1.31 in package.json and package-lock.json

* function return type its mandatory

* fixed lint issues and added story for negative number validation

---------



* Add support for spreadsheet file types in constants and types (#29)

---------