### PR TITLE
Refactor dropdown handling in Multiselect and Select components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "axios": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-/* global MouseEvent, Node, document, HTMLElement */
+/* global HTMLElement */
 import { ref, computed, toRef, reactive, watch, onUnmounted } from 'vue';
 import type { SelectProps, MultiselectOption } from '@/types';
 import { useSelector } from '@/composables/useSelector';
@@ -45,6 +45,8 @@ const shouldShowMeta = computed(
   () => showHelperText.value || showErrorMessage.value,
 );
 
+const teleportedDropdownRef = ref<HTMLElement | null>(null);
+
 // Use shared selector composable
 const {
   isOpen,
@@ -63,14 +65,13 @@ const {
   searchable: toRef(props, 'searchable'),
   disableAutofilter: toRef(props, 'disableAutofilter'),
   closeOnSelect: ref(true),
+  teleportedDropdownRef,
   emit: {
     open: () => emit('open'),
     close: () => emit('close'),
     updateSearchQuery: (value: string) => emit('update:searchQuery', value),
   },
 });
-
-const teleportedDropdownRef = ref<HTMLElement | null>(null);
 
 // Get selected option
 const selectedOption = computed(() => {
@@ -136,39 +137,21 @@ const updateDropdownPosition = (): void => {
   dropdownPosition.width = rect.width;
 };
 
-// Custom click outside handler for teleported dropdown
-const handleTeleportedClickOutside = (event: MouseEvent): void => {
-  if (!props.appendToBody || !isOpen.value) return;
-
-  const target = event.target as Node;
-  const isInsideTeleported = teleportedDropdownRef.value?.contains(target);
-
-  // If click is inside the teleported dropdown, stop propagation to prevent
-  // the useSelector's click outside handler from closing the dropdown
-  if (isInsideTeleported) {
-    event.stopPropagation();
-  }
-};
-
 // Watch isOpen to add/remove event listeners for position updates
 watch(isOpen, (open) => {
   if (open && props.appendToBody) {
     updateDropdownPosition();
     window.addEventListener('scroll', updateDropdownPosition, true);
     window.addEventListener('resize', updateDropdownPosition);
-    // Add click outside handler for teleported dropdown
-    document.addEventListener('click', handleTeleportedClickOutside, true);
   } else {
     window.removeEventListener('scroll', updateDropdownPosition, true);
     window.removeEventListener('resize', updateDropdownPosition);
-    document.removeEventListener('click', handleTeleportedClickOutside, true);
   }
 });
 
 onUnmounted(() => {
   window.removeEventListener('scroll', updateDropdownPosition, true);
   window.removeEventListener('resize', updateDropdownPosition);
-  document.removeEventListener('click', handleTeleportedClickOutside, true);
 });
 </script>
 

--- a/src/composables/useSelector.ts
+++ b/src/composables/useSelector.ts
@@ -21,6 +21,8 @@ export interface UseSelectorOptions {
   closeOnSelect?: Ref<boolean>;
   /** When true, disables client-side filtering (backend handles filtering) */
   disableAutofilter?: Ref<boolean>;
+  /** Reference to teleported dropdown element (for appendToBody) */
+  teleportedDropdownRef?: Ref<HTMLElement | null>;
   /** Emit functions */
   emit: {
     open: () => void;
@@ -63,6 +65,7 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
     searchable = ref(true),
     closeOnSelect: _closeOnSelect = ref(true),
     disableAutofilter = ref(false),
+    teleportedDropdownRef,
     emit,
   } = options;
 
@@ -76,7 +79,7 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
     () => searchQueryProp?.value ?? internalSearchQuery.value,
   );
 
-  const setSearchQuery = (value: string) => {
+  const setSearchQuery = (value: string): void => {
     internalSearchQuery.value = value;
     emit.updateSearchQuery(value);
   };
@@ -99,7 +102,7 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
   });
 
   // Open dropdown
-  const openDropdown = () => {
+  const openDropdown = (): void => {
     if (!isOpen.value) {
       isOpen.value = true;
       emit.open();
@@ -107,7 +110,7 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
   };
 
   // Close dropdown
-  const closeDropdown = () => {
+  const closeDropdown = (): void => {
     if (isOpen.value) {
       isOpen.value = false;
       setSearchQuery('');
@@ -119,7 +122,7 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
   };
 
   // Toggle dropdown
-  const toggleDropdown = () => {
+  const toggleDropdown = (): void => {
     if (isOpen.value) {
       closeDropdown();
     } else {
@@ -128,21 +131,22 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
   };
 
   // Handle input focus
-  const handleInputFocus = () => {
+  const handleInputFocus = (): void => {
     openDropdown();
   };
 
   // Check if option is disabled
-  const isOptionDisabled = (option: MultiselectOption) => {
+  const isOptionDisabled = (option: MultiselectOption): boolean => {
     return option.disabled ?? false;
   };
 
   // Handle click outside to close dropdown
-  const handleClickOutside = (event: MouseEvent) => {
-    if (
-      dropdownRef.value &&
-      !dropdownRef.value.contains(event.target as Node)
-    ) {
+  const handleClickOutside = (event: MouseEvent): void => {
+    const target = event.target as Node;
+    const isInsideDropdown = dropdownRef.value?.contains(target);
+    const isInsideTeleported = teleportedDropdownRef?.value?.contains(target);
+
+    if (dropdownRef.value && !isInsideDropdown && !isInsideTeleported) {
       closeDropdown();
     }
   };


### PR DESCRIPTION
# Context

The Select component with `appendToBody` was not allowing option selection. The issue was that when the dropdown was teleported to `<body>`, the `handleClickOutside` handler in `useSelector` only checked if the click was inside the main container (`dropdownRef`), ignoring the teleported dropdown. This caused the dropdown to close before `selectOption` could execute.

The solution was to modify the `useSelector` composable to accept an optional `teleportedDropdownRef` parameter and verify if the click is inside either element before closing.

# Changes

- **src/composables/useSelector.ts**: Added optional `teleportedDropdownRef` parameter to `UseSelectorOptions` interface. Updated `handleClickOutside` to check if the click is inside the teleported dropdown in addition to the main container.

- **src/components/Select/Select.vue**: Moved `teleportedDropdownRef` before the composable call and passed it as a parameter to `useSelector`. Removed the `handleTeleportedClickOutside` handler which is no longer needed.

- **src/components/Multiselect/Multiselect.vue**: Same change applied for consistency - passed `teleportedDropdownRef` to the composable and removed the redundant `handleTeleportedClickOutside` handler.

# Evidence

![2026-01-14 02 48 43](https://github.com/user-attachments/assets/4c9f2ef4-8e2f-4fd3-9955-2e8e2ea666da)
![2026-01-14 02 49 07](https://github.com/user-attachments/assets/4205ddd7-efc3-4ee2-9e5b-7271866795ae)
