### PR TITLE
Ignore keyboard events from interactive elements and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "axios": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -32,11 +32,6 @@
         "import": "./dist/Accordion/index.js",
         "require": "./dist/design-system-vue.umd.js"
       },
-      "./AccordionGroup": {
-        "types": "./dist/AccordionGroup/index.d.ts",
-        "import": "./dist/AccordionGroup/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
       "./BackgroundWrapper": {
         "types": "./dist/BackgroundWrapper/index.d.ts",
         "import": "./dist/BackgroundWrapper/index.js",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
         "import": "./dist/Accordion/index.js",
         "require": "./dist/design-system-vue.umd.js"
       },
+      "./AccordionGroup": {
+        "types": "./dist/AccordionGroup/index.d.ts",
+        "import": "./dist/AccordionGroup/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
       "./BackgroundWrapper": {
         "types": "./dist/BackgroundWrapper/index.d.ts",
         "import": "./dist/BackgroundWrapper/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",

--- a/src/components/TreeItem/TreeItem.vue
+++ b/src/components/TreeItem/TreeItem.vue
@@ -90,6 +90,19 @@ const handleArrowKey = (
 const handleKeydown = (event: globalThis.KeyboardEvent): void => {
   if (props.item.disabled) return;
 
+  // Ignore keyboard events from interactive elements (inputs, textareas, etc.)
+  const target = event.target as {
+    tagName?: string;
+    isContentEditable?: boolean;
+  };
+  const isInteractiveElement =
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA' ||
+    target.tagName === 'SELECT' ||
+    target.isContentEditable;
+
+  if (isInteractiveElement) return;
+
   switch (event.key) {
     case 'Enter':
     case ' ':

--- a/src/components/TreeList/__stories__/TreeList.stories.ts
+++ b/src/components/TreeList/__stories__/TreeList.stories.ts
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { ref } from 'vue';
 import TreeList from '../TreeList.vue';
+import TextInput from '../../TextInput/TextInput.vue';
+import Checkbox from '../../Checkbox/Checkbox.vue';
+import Tooltip from '../../Tooltip/Tooltip.vue';
 import type { TreeItemData } from '@/types';
 
 const meta: Meta<typeof TreeList> = {
@@ -271,6 +274,178 @@ export const DeepNesting: Story = {
         v-model:expanded-ids="expandedIds"
         draggable
       />
+    `,
+  }),
+};
+
+export const WithEditableInputs: Story = {
+  render: () => ({
+    components: {
+      TreeList,
+      TextInput,
+      Checkbox,
+      Tooltip,
+    },
+    setup() {
+      const items = ref<TreeItemData[]>([
+        {
+          id: 'cat-1',
+          label: '[Category name]',
+          meta: '[Node ID]',
+          children: [
+            {
+              id: 'subcat-1',
+              label: '[Sub-category name]',
+              meta: '[Node ID]',
+            },
+            {
+              id: 'subcat-2',
+              label: '[Sub-category name]',
+              meta: '[Node ID]',
+              children: [
+                {
+                  id: 'subsub-1',
+                  label: '[Sub-sub category]',
+                  meta: '[Node ID]',
+                },
+                {
+                  id: 'subsub-2',
+                  label: '[Sub-sub category]',
+                  meta: '[Node ID]',
+                },
+                {
+                  id: 'subsub-3',
+                  label: '[Sub-sub category]',
+                  meta: '[Node ID]',
+                },
+                {
+                  id: 'subsub-4',
+                  label: '[Sub-sub category]',
+                  meta: '[Node ID]',
+                },
+                {
+                  id: 'subsub-5',
+                  label: '[Sub-sub category]',
+                  meta: '[Node ID]',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'cat-2',
+          label: '[Category name]',
+          meta: '[Node ID]',
+        },
+      ]);
+      const expandedIds = ref<(string | number)[]>(['cat-1', 'subcat-2']);
+      const visibility = ref<Record<string, boolean>>({});
+
+      const getVisibility = (id: string | number): boolean => {
+        return visibility.value[id] ?? false;
+      };
+
+      const toggleVisibility = (id: string | number): void => {
+        visibility.value[id] = !getVisibility(id);
+      };
+
+      const updateLabel = (item: TreeItemData, value: string): void => {
+        item.label = value;
+      };
+
+      const flattenOrder = (
+        itemsList: TreeItemData[],
+        depth = 0,
+      ): Array<{
+        id: string | number;
+        label: string;
+        depth: number;
+      }> => {
+        const result: Array<{
+          id: string | number;
+          label: string;
+          depth: number;
+        }> = [];
+        for (const item of itemsList) {
+          result.push({
+            id: item.id,
+            label: item.label,
+            depth,
+          });
+          if (item.children && item.children.length > 0) {
+            result.push(...flattenOrder(item.children, depth + 1));
+          }
+        }
+        return result;
+      };
+
+      const orderLog = ref(flattenOrder(items.value));
+
+      const handleReorder = (): void => {
+        orderLog.value = flattenOrder(items.value);
+        console.log('Order updated:', orderLog.value);
+      };
+
+      return {
+        items,
+        expandedIds,
+        visibility,
+        getVisibility,
+        toggleVisibility,
+        updateLabel,
+        orderLog,
+        handleReorder,
+      };
+    },
+    template: `
+      <div>
+        <p style="margin-bottom: 16px; color: #666;">
+          Test typing spaces in the TextInput fields - they should work normally without expanding/collapsing nodes.
+        </p>
+        <TreeList
+          v-model:items="items"
+          v-model:expanded-ids="expandedIds"
+          draggable
+          bordered
+          :indent-size="24"
+          @reorder="handleReorder"
+        >
+          <template #label="{ item }">
+            <Tooltip content="Category name" position="top">
+              <TextInput
+                :model-value="item.label"
+                size="small"
+                :width="160"
+                @update:model-value="updateLabel(item, $event)"
+                @click.stop
+              />
+            </Tooltip>
+          </template>
+          <template #meta="{ item }">
+            <Tooltip content="Category ID" position="top">
+              <span style="color: #666; font-size: 12px;">{{ item.meta }}</span>
+            </Tooltip>
+          </template>
+          <template #suffix="{ item }">
+            <Tooltip content="Visible to customers" position="top">
+              <Checkbox
+                :checked="getVisibility(item.id)"
+                size="small"
+                @update:checked="toggleVisibility(item.id)"
+                @click.stop
+              >
+                Visible to customers
+              </Checkbox>
+            </Tooltip>
+          </template>
+        </TreeList>
+        <div style="margin-top: 16px; padding: 12px; background: #f5f5f5; border-radius: 4px; font-size: 13px; font-family: monospace;">
+          <strong style="display: block; margin-bottom: 8px;">Item order:</strong>
+          <div v-for="item in orderLog" :key="item.id" :style="{ paddingLeft: item.depth * 16 + 'px' }">
+            {{ item.id }} - {{ item.label }}
+          </div>
+        </div>
+      </div>
     `,
   }),
 };


### PR DESCRIPTION
# Context

This PR implements logic to ignore keyboard events from interactive elements within tree nodes and adds stories to test editable inputs in TreeList. The package version is also updated.

# Changes

package.json: Bump version from 0.1.42 to 0.1.43 and add export for AccordionGroup.
package-lock.json: Update locked version to 0.1.43.
src/components/TreeItem/TreeItem.vue: Ignore keyboard events from interactive elements (inputs, textareas, selects, contenteditable) to prevent conflicts when editing fields inside nodes.
src/components/TreeList/stories/TreeList.stories.ts: Add "WithEditableInputs" story to test editable inputs and checkboxes inside TreeList, ensuring keyboard events do not interfere with field interaction.


# Evidence
![2026-01-15 01 03 27](https://github.com/user-attachments/assets/9793145a-775f-4fb8-959d-1e6c5727aad1)


