### PR TITLE
feat: Add hover effect and overflow hidden to TreeItem component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "axios": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -32,11 +32,6 @@
         "import": "./dist/Accordion/index.js",
         "require": "./dist/design-system-vue.umd.js"
       },
-      "./AccordionGroup": {
-        "types": "./dist/AccordionGroup/index.d.ts",
-        "import": "./dist/AccordionGroup/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
       "./BackgroundWrapper": {
         "types": "./dist/BackgroundWrapper/index.d.ts",
         "import": "./dist/BackgroundWrapper/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",
@@ -30,6 +30,11 @@
       "./Accordion": {
         "types": "./dist/Accordion/index.d.ts",
         "import": "./dist/Accordion/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./AccordionGroup": {
+        "types": "./dist/AccordionGroup/index.d.ts",
+        "import": "./dist/AccordionGroup/index.js",
         "require": "./dist/design-system-vue.umd.js"
       },
       "./BackgroundWrapper": {

--- a/src/components/TreeItem/TreeItem.vue
+++ b/src/components/TreeItem/TreeItem.vue
@@ -283,6 +283,10 @@ const handleDrop = (event: globalThis.DragEvent): void => {
     /* Striped rows - odd rows get alternate background */
     &[data-odd-row='true'] > .tree-item__content {
       background-color: var(--color-neutral-100);
+
+      &:hover {
+        background-color: var(--color-neutral-200);
+      }
     }
 
     .tree-item__content {
@@ -316,6 +320,7 @@ const handleDrop = (event: globalThis.DragEvent): void => {
       margin-bottom: var(--spacing-xs);
       width: 100%;
       box-sizing: border-box;
+      overflow: hidden;
 
       > .tree-item__content {
         padding-left: var(--spacing-md);

--- a/src/components/TreeList/__stories__/TreeList.stories.ts
+++ b/src/components/TreeList/__stories__/TreeList.stories.ts
@@ -407,6 +407,7 @@ export const WithEditableInputs: Story = {
           v-model:expanded-ids="expandedIds"
           draggable
           bordered
+          striped
           :indent-size="24"
           @reorder="handleReorder"
         >


### PR DESCRIPTION
# Context

This PR enhances the TreeItem component with visual improvements.

## Changes

### TreeItem Component (`src/components/TreeItem/TreeItem.vue`)
- **Added hover effect for striped rows**: When `striped` prop is enabled, odd rows now have a hover effect that changes the background from `--color-neutral-100` to `--color-neutral-200`
- **Added overflow hidden**: Applied `overflow: hidden` to `.tree-item` to prevent content from overflowing the component boundaries

### TreeList Stories (`src/components/TreeList/__stories__/TreeList.stories.ts`)
- Enabled `striped` prop in the `WithEditableInputs` story to showcase the striped styling feature

### Package Configuration
- Bumped version from `0.1.43` to `0.1.44`

# Evidence

![2026-01-16 12 59 34](https://github.com/user-attachments/assets/18192b7d-51a6-466d-9a78-666015ec75a4)
