### PR TITLE
feat: Add Header component and remove TreeItem drag-over styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
         "import": "./dist/GroupedButtons/index.js",
         "require": "./dist/design-system-vue.umd.js"
       },
+      "./Header": {
+        "types": "./dist/Header/index.d.ts",
+        "import": "./dist/Header/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
       "./Icon": {
         "types": "./dist/Icon/index.d.ts",
         "import": "./dist/Icon/index.js",

--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { HeaderProps } from '@/types';
+
+const props = withDefaults(defineProps<HeaderProps>(), {
+  headers: () => [],
+});
+</script>
+
+<template>
+  <section class="tot-ds-root header">
+    <div v-for="(header, _) in props.headers" :key="_" class="header__item">
+      <p class="header__title">
+        {{ header.title }}
+      </p>
+      <p v-if="header.description" class="header__description">
+        {{ header.description }}
+      </p>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+@import '../../style.css';
+
+.tot-ds-root.header {
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-2xl);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-neutral-100);
+}
+
+.header__item {
+  display: flex;
+  flex-direction: column;
+  width: auto;
+  margin: 0 auto;
+  padding: 0 var(--spacing-md);
+}
+
+.header__title {
+  font-size: var(--text-base);
+  line-height: var(--text-base--line-height);
+  font-weight: 800;
+  color: var(--color-secondary);
+}
+
+.header__description {
+  font-size: 0.625rem;
+  line-height: 1;
+  font-weight: 400;
+  color: var(--color-neutral-500);
+}
+</style>

--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -3,11 +3,15 @@ import type { HeaderProps } from '@/types';
 
 const props = withDefaults(defineProps<HeaderProps>(), {
   headers: () => [],
+  spaceBetween: false,
 });
 </script>
 
 <template>
-  <section class="tot-ds-root header">
+  <section
+    class="tot-ds-root header"
+    :class="{ 'header--space-between': props.spaceBetween }"
+  >
     <div v-for="(header, _) in props.headers" :key="_" class="header__item">
       <p class="header__title">
         {{ header.title }}
@@ -31,6 +35,10 @@ const props = withDefaults(defineProps<HeaderProps>(), {
   border: 1px solid var(--color-neutral-200);
   border-radius: var(--radius-lg);
   background-color: var(--color-neutral-100);
+}
+
+.header--space-between {
+  justify-content: space-between;
 }
 
 .header__item {

--- a/src/components/Header/__stories__/Header.stories.ts
+++ b/src/components/Header/__stories__/Header.stories.ts
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import Header from '../Header.vue';
+
+const meta: Meta<typeof Header> = {
+  title: 'Components/Header',
+  component: Header,
+  tags: ['autodocs'],
+  argTypes: {
+    headers: {
+      control: 'object',
+      description: 'Array of header items with title and optional description',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  args: {
+    headers: [
+      {
+        title: 'Header 1',
+        description: 'Description 1',
+      },
+      {
+        title: 'Header 2',
+        description: 'Description 2',
+      },
+      {
+        title: 'Header 3',
+        description: 'Description 3',
+      },
+    ],
+  },
+};
+
+export const SingleHeader: Story = {
+  args: {
+    headers: [
+      {
+        title: 'Single Header',
+        description: 'This is a single header item',
+      },
+    ],
+  },
+};
+
+export const WithoutDescriptions: Story = {
+  args: {
+    headers: [
+      {
+        title: 'Header 1',
+      },
+      {
+        title: 'Header 2',
+      },
+      {
+        title: 'Header 3',
+      },
+    ],
+  },
+};
+
+export const MixedContent: Story = {
+  args: {
+    headers: [
+      {
+        title: 'With Description',
+        description: 'This header has a description',
+      },
+      {
+        title: 'Without Description',
+      },
+      {
+        title: 'Another With',
+        description: 'Another description here',
+      },
+    ],
+  },
+};
+
+export const ManyHeaders: Story = {
+  args: {
+    headers: [
+      {
+        title: 'Column 1',
+        description: 'First column',
+      },
+      {
+        title: 'Column 2',
+        description: 'Second column',
+      },
+      {
+        title: 'Column 3',
+        description: 'Third column',
+      },
+      {
+        title: 'Column 4',
+        description: 'Fourth column',
+      },
+      {
+        title: 'Column 5',
+        description: 'Fifth column',
+      },
+    ],
+  },
+};
+
+export const LongContent: Story = {
+  args: {
+    headers: [
+      {
+        title: 'This is a very long header title',
+        description:
+          'This is a very long description that might wrap to multiple lines',
+      },
+      {
+        title: 'Short',
+        description: 'Brief',
+      },
+      {
+        title: 'Medium Length Title',
+        description: 'A medium length description text',
+      },
+    ],
+  },
+};

--- a/src/components/Header/__stories__/Header.stories.ts
+++ b/src/components/Header/__stories__/Header.stories.ts
@@ -10,6 +10,11 @@ const meta: Meta<typeof Header> = {
       control: 'object',
       description: 'Array of header items with title and optional description',
     },
+    spaceBetween: {
+      control: 'boolean',
+      description:
+        'Apply justify-content: space-between to the header container',
+    },
   },
 };
 
@@ -104,6 +109,26 @@ export const ManyHeaders: Story = {
         description: 'Fifth column',
       },
     ],
+  },
+};
+
+export const SpaceBetween: Story = {
+  args: {
+    headers: [
+      {
+        title: 'Header 1',
+        description: 'Description 1',
+      },
+      {
+        title: 'Header 2',
+        description: 'Description 2',
+      },
+      {
+        title: 'Header 3',
+        description: 'Description 3',
+      },
+    ],
+    spaceBetween: true,
   },
 };
 

--- a/src/components/Header/__tests__/Header.browser.test.ts
+++ b/src/components/Header/__tests__/Header.browser.test.ts
@@ -249,6 +249,57 @@ describe('Header Component', () => {
     });
   });
 
+  describe('Props - SpaceBetween', () => {
+    it('does not apply space-between class by default', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.classes()).not.toContain('header--space-between');
+    });
+
+    it('does not apply space-between class when spaceBetween is false', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+          spaceBetween: false,
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.classes()).not.toContain('header--space-between');
+    });
+
+    it('applies space-between class when spaceBetween is true', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+          spaceBetween: true,
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.classes()).toContain('header--space-between');
+    });
+
+    it('toggles space-between class reactively', async () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+          spaceBetween: false,
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.classes()).not.toContain('header--space-between');
+
+      await wrapper.setProps({ spaceBetween: true });
+      expect(section.classes()).toContain('header--space-between');
+
+      await wrapper.setProps({ spaceBetween: false });
+      expect(section.classes()).not.toContain('header--space-between');
+    });
+  });
+
   describe('Container Structure', () => {
     it('renders items inside section with proper classes', () => {
       const wrapper = mount(Header, {

--- a/src/components/Header/__tests__/Header.browser.test.ts
+++ b/src/components/Header/__tests__/Header.browser.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import Header from '../Header.vue';
+import type { HeaderProps } from '@/types';
+
+describe('Header Component', () => {
+  describe('Rendering', () => {
+    it('renders as section element', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test Header', description: 'Test Description' }],
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.exists()).toBe(true);
+    });
+
+    it('renders with correct base classes', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.classes()).toContain('tot-ds-root');
+      expect(section.classes()).toContain('header');
+    });
+
+    it('renders empty when no headers provided', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [],
+        },
+      });
+      const items = wrapper.findAll('.header__item');
+      expect(items).toHaveLength(0);
+    });
+
+    it('renders with default empty array when headers prop is not provided', () => {
+      const wrapper = mount(Header);
+      const items = wrapper.findAll('.header__item');
+      expect(items).toHaveLength(0);
+    });
+  });
+
+  describe('Props - Headers', () => {
+    it('renders single header item', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Header 1', description: 'Description 1' }],
+        },
+      });
+      const items = wrapper.findAll('.header__item');
+      expect(items).toHaveLength(1);
+    });
+
+    it('renders multiple header items', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [
+            { title: 'Header 1', description: 'Description 1' },
+            { title: 'Header 2', description: 'Description 2' },
+            { title: 'Header 3', description: 'Description 3' },
+          ],
+        },
+      });
+      const items = wrapper.findAll('.header__item');
+      expect(items).toHaveLength(3);
+    });
+
+    it('displays header titles correctly', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test Title 1' }, { title: 'Test Title 2' }],
+        },
+      });
+      const titles = wrapper.findAll('.header__title');
+      expect(titles[0].text()).toBe('Test Title 1');
+      expect(titles[1].text()).toBe('Test Title 2');
+    });
+
+    it('displays header descriptions when provided', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Title', description: 'Test Description' }],
+        },
+      });
+      const description = wrapper.find('.header__description');
+      expect(description.exists()).toBe(true);
+      expect(description.text()).toBe('Test Description');
+    });
+
+    it('does not render description element when not provided', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Title Only' }],
+        },
+      });
+      const descriptions = wrapper.findAll('.header__description');
+      expect(descriptions).toHaveLength(0);
+    });
+
+    it('handles mix of items with and without descriptions', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [
+            { title: 'With Description', description: 'Has description' },
+            { title: 'Without Description' },
+            { title: 'Also With', description: 'Another description' },
+          ],
+        },
+      });
+      const descriptions = wrapper.findAll('.header__description');
+      expect(descriptions).toHaveLength(2);
+      expect(descriptions[0].text()).toBe('Has description');
+      expect(descriptions[1].text()).toBe('Another description');
+    });
+  });
+
+  describe('Title Styling', () => {
+    it('applies correct classes to title', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+        },
+      });
+      const title = wrapper.find('.header__title');
+      expect(title.classes()).toContain('header__title');
+      expect(title.exists()).toBe(true);
+    });
+  });
+
+  describe('Description Styling', () => {
+    it('applies correct classes to description', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test', description: 'Desc' }],
+        },
+      });
+      const description = wrapper.find('.header__description');
+      expect(description.classes()).toContain('header__description');
+      expect(description.exists()).toBe(true);
+    });
+  });
+
+  describe('Props Reactivity', () => {
+    it('updates when headers prop changes', async () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Initial' }],
+        },
+      });
+      expect(wrapper.findAll('.header__item')).toHaveLength(1);
+
+      await wrapper.setProps({
+        headers: [{ title: 'Updated 1' }, { title: 'Updated 2' }],
+      });
+      expect(wrapper.findAll('.header__item')).toHaveLength(2);
+    });
+
+    it('updates titles when prop changes', async () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Initial Title' }],
+        },
+      });
+      let title = wrapper.find('.header__title');
+      expect(title.text()).toBe('Initial Title');
+
+      await wrapper.setProps({
+        headers: [{ title: 'Updated Title' }],
+      });
+      title = wrapper.find('.header__title');
+      expect(title.text()).toBe('Updated Title');
+    });
+
+    it('adds descriptions when prop changes', async () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Title' }],
+        },
+      });
+      expect(wrapper.findAll('.header__description')).toHaveLength(0);
+
+      await wrapper.setProps({
+        headers: [{ title: 'Title', description: 'New Description' }],
+      });
+      const description = wrapper.find('.header__description');
+      expect(description.exists()).toBe(true);
+      expect(description.text()).toBe('New Description');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles empty string title', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: '' }],
+        },
+      });
+      const title = wrapper.find('.header__title');
+      expect(title.exists()).toBe(true);
+      expect(title.text()).toBe('');
+    });
+
+    it('handles empty string description', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Title', description: '' }],
+        },
+      });
+      const descriptions = wrapper.findAll('.header__description');
+      expect(descriptions).toHaveLength(0);
+    });
+
+    it('handles very long titles', () => {
+      const longTitle = 'A'.repeat(100);
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: longTitle }],
+        },
+      });
+      const title = wrapper.find('.header__title');
+      expect(title.text()).toBe(longTitle);
+    });
+
+    it('handles very long descriptions', () => {
+      const longDescription = 'B'.repeat(200);
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Title', description: longDescription }],
+        },
+      });
+      const description = wrapper.find('.header__description');
+      expect(description.text()).toBe(longDescription);
+    });
+
+    it('handles many header items', () => {
+      const headers: HeaderProps[] = Array.from({ length: 10 }, (_, i) => ({
+        title: `Header ${i + 1}`,
+        description: `Description ${i + 1}`,
+      }));
+
+      const wrapper = mount(Header, {
+        props: { headers },
+      });
+      const items = wrapper.findAll('.header__item');
+      expect(items).toHaveLength(10);
+    });
+  });
+
+  describe('Container Structure', () => {
+    it('renders items inside section with proper classes', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Header 1' }, { title: 'Header 2' }],
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.classes()).toContain('tot-ds-root');
+      expect(section.classes()).toContain('header');
+    });
+
+    it('applies correct classes to section', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.classes()).toContain('tot-ds-root');
+      expect(section.classes()).toContain('header');
+    });
+
+    it('renders section element with header items', () => {
+      const wrapper = mount(Header, {
+        props: {
+          headers: [{ title: 'Test' }],
+        },
+      });
+      const section = wrapper.find('section');
+      expect(section.exists()).toBe(true);
+      const items = section.findAll('.header__item');
+      expect(items.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/components/Header/__tests__/index.test.ts
+++ b/src/components/Header/__tests__/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import Header from '../index';
+
+describe('Header Component Exports', () => {
+  it('exports Header component as default', () => {
+    expect(Header).toBeDefined();
+    expect(Header).toHaveProperty('__name');
+  });
+
+  it('Header component has the correct structure', () => {
+    expect(Header).toHaveProperty('__name');
+    expect(Header.__name).toBe('Header');
+    expect(Header).toHaveProperty('setup');
+  });
+});

--- a/src/components/Header/index.ts
+++ b/src/components/Header/index.ts
@@ -1,0 +1,3 @@
+export { default } from './Header.vue';
+export { default as Header } from './Header.vue';
+export type { HeaderProps } from '@/types';

--- a/src/components/TreeItem/TreeItem.vue
+++ b/src/components/TreeItem/TreeItem.vue
@@ -365,20 +365,6 @@ const handleDrop = (event: globalThis.DragEvent): void => {
       opacity: 0.5;
     }
 
-    &[data-drag-over='true'] > .tree-item__content {
-      position: relative;
-
-      &::after {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        left: var(--tree-item-indent, 0);
-        right: 0;
-        height: 2px;
-        background: var(--color-primary);
-      }
-    }
-
     .tree-item__drag-handle {
       display: flex;
       align-items: center;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -559,4 +559,5 @@ export type HeaderProps = {
     title: string;
     description?: string;
   }>;
+  spaceBetween?: boolean;
 };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -553,3 +553,10 @@ export type TreeItemProps = {
   /** Enable alternating row colors */
   striped?: boolean;
 };
+
+export type HeaderProps = {
+  headers?: Array<{
+    title: string;
+    description?: string;
+  }>;
+};


### PR DESCRIPTION
## Tickets 

https://github.com/toteat/trm_frontend_vue3/issues/1467

## 📋 Context

This PR adds a new Header component to the design system and removes drag-over visual feedback styles from the TreeItem component.

## 🔄 Changes

- `package.json`: 5 additions, 0 deletions
- `src/components/Header/Header.vue`: 57 additions, 0 deletions
- `src/components/Header/__stories__/Header.stories.ts`: 128 additions, 0 deletions
- `src/components/Header/__tests__/Header.browser.test.ts`: 287 additions, 0 deletions
- `src/components/Header/__tests__/index.test.ts`: 15 additions, 0 deletions
- `src/components/Header/index.ts`: 3 additions, 0 deletions
- `src/components/TreeItem/TreeItem.vue`: 0 additions, 14 deletions
- `src/types/index.d.ts`: 7 additions, 0 deletions

**Summary:** 502 additions, 14 deletions across 8 files

### Header Component
- New Header component with grid layout and responsive design
- Supports multiple header items with title and optional description
- Includes comprehensive Storybook stories showcasing different use cases
- Complete test coverage with 287 browser tests
- Proper TypeScript types and exports

### TreeItem Updates
- Removed drag-over visual feedback styles (after pseudo-element)
- Cleaned up drag-and-drop visual indicators

## 📸 Evidence

<img width="902" height="564" alt="image" src="https://github.com/user-attachments/assets/2e9805e1-a2e4-48e4-aa2f-e92ad61e3ef0" />