### PR TITLE
updated to version 0.1.47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "axios": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated @toteat-eng/design-system-vue to version 0.1.47 to prepare the next patch release. Updated package.json and package-lock.json; no functional changes.

<sup>Written for commit cd6b0f599dfa9d12d638a7ec6949d846bd2db211. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

