### PR TITLE
feat(TreeItem): enhance styles and add bordered prop to TreeList stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,138 +22,138 @@
     "dist"
   ],
   "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/design-system-vue.es.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Accordion": {
-        "types": "./dist/Accordion/index.d.ts",
-        "import": "./dist/Accordion/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./BackgroundWrapper": {
-        "types": "./dist/BackgroundWrapper/index.d.ts",
-        "import": "./dist/BackgroundWrapper/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Button": {
-        "types": "./dist/Button/index.d.ts",
-        "import": "./dist/Button/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Card": {
-        "types": "./dist/Card/index.d.ts",
-        "import": "./dist/Card/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Checkbox": {
-        "types": "./dist/Checkbox/index.d.ts",
-        "import": "./dist/Checkbox/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./DropZone": {
-        "types": "./dist/DropZone/index.d.ts",
-        "import": "./dist/DropZone/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./DropdownButton": {
-        "types": "./dist/DropdownButton/index.d.ts",
-        "import": "./dist/DropdownButton/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./GroupedButtons": {
-        "types": "./dist/GroupedButtons/index.d.ts",
-        "import": "./dist/GroupedButtons/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Header": {
-        "types": "./dist/Header/index.d.ts",
-        "import": "./dist/Header/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Icon": {
-        "types": "./dist/Icon/index.d.ts",
-        "import": "./dist/Icon/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./ImagePreview": {
-        "types": "./dist/ImagePreview/index.d.ts",
-        "import": "./dist/ImagePreview/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./LogoToteat": {
-        "types": "./dist/LogoToteat/index.d.ts",
-        "import": "./dist/LogoToteat/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Multiselect": {
-        "types": "./dist/Multiselect/index.d.ts",
-        "import": "./dist/Multiselect/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Overlay": {
-        "types": "./dist/Overlay/index.d.ts",
-        "import": "./dist/Overlay/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./OverlayMessage": {
-        "types": "./dist/OverlayMessage/index.d.ts",
-        "import": "./dist/OverlayMessage/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Radio": {
-        "types": "./dist/Radio/index.d.ts",
-        "import": "./dist/Radio/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Select": {
-        "types": "./dist/Select/index.d.ts",
-        "import": "./dist/Select/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./SkeletonPreload": {
-        "types": "./dist/SkeletonPreload/index.d.ts",
-        "import": "./dist/SkeletonPreload/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Spinner": {
-        "types": "./dist/Spinner/index.d.ts",
-        "import": "./dist/Spinner/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Tab": {
-        "types": "./dist/Tab/index.d.ts",
-        "import": "./dist/Tab/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Table": {
-        "types": "./dist/Table/index.d.ts",
-        "import": "./dist/Table/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./TextInput": {
-        "types": "./dist/TextInput/index.d.ts",
-        "import": "./dist/TextInput/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./Tooltip": {
-        "types": "./dist/Tooltip/index.d.ts",
-        "import": "./dist/Tooltip/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./TreeItem": {
-        "types": "./dist/TreeItem/index.d.ts",
-        "import": "./dist/TreeItem/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./TreeList": {
-        "types": "./dist/TreeList/index.d.ts",
-        "import": "./dist/TreeList/index.js",
-        "require": "./dist/design-system-vue.umd.js"
-      },
-      "./style.css": "./dist/design-system-vue.css"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/design-system-vue.es.js",
+      "require": "./dist/design-system-vue.umd.js"
     },
+    "./Accordion": {
+      "types": "./dist/Accordion/index.d.ts",
+      "import": "./dist/Accordion/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./BackgroundWrapper": {
+      "types": "./dist/BackgroundWrapper/index.d.ts",
+      "import": "./dist/BackgroundWrapper/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Button": {
+      "types": "./dist/Button/index.d.ts",
+      "import": "./dist/Button/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Card": {
+      "types": "./dist/Card/index.d.ts",
+      "import": "./dist/Card/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Checkbox": {
+      "types": "./dist/Checkbox/index.d.ts",
+      "import": "./dist/Checkbox/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./DropZone": {
+      "types": "./dist/DropZone/index.d.ts",
+      "import": "./dist/DropZone/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./DropdownButton": {
+      "types": "./dist/DropdownButton/index.d.ts",
+      "import": "./dist/DropdownButton/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./GroupedButtons": {
+      "types": "./dist/GroupedButtons/index.d.ts",
+      "import": "./dist/GroupedButtons/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Header": {
+      "types": "./dist/Header/index.d.ts",
+      "import": "./dist/Header/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Icon": {
+      "types": "./dist/Icon/index.d.ts",
+      "import": "./dist/Icon/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./ImagePreview": {
+      "types": "./dist/ImagePreview/index.d.ts",
+      "import": "./dist/ImagePreview/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./LogoToteat": {
+      "types": "./dist/LogoToteat/index.d.ts",
+      "import": "./dist/LogoToteat/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Multiselect": {
+      "types": "./dist/Multiselect/index.d.ts",
+      "import": "./dist/Multiselect/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Overlay": {
+      "types": "./dist/Overlay/index.d.ts",
+      "import": "./dist/Overlay/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./OverlayMessage": {
+      "types": "./dist/OverlayMessage/index.d.ts",
+      "import": "./dist/OverlayMessage/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Radio": {
+      "types": "./dist/Radio/index.d.ts",
+      "import": "./dist/Radio/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Select": {
+      "types": "./dist/Select/index.d.ts",
+      "import": "./dist/Select/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./SkeletonPreload": {
+      "types": "./dist/SkeletonPreload/index.d.ts",
+      "import": "./dist/SkeletonPreload/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Spinner": {
+      "types": "./dist/Spinner/index.d.ts",
+      "import": "./dist/Spinner/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Tab": {
+      "types": "./dist/Tab/index.d.ts",
+      "import": "./dist/Tab/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Table": {
+      "types": "./dist/Table/index.d.ts",
+      "import": "./dist/Table/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./TextInput": {
+      "types": "./dist/TextInput/index.d.ts",
+      "import": "./dist/TextInput/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./Tooltip": {
+      "types": "./dist/Tooltip/index.d.ts",
+      "import": "./dist/Tooltip/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./TreeItem": {
+      "types": "./dist/TreeItem/index.d.ts",
+      "import": "./dist/TreeItem/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./TreeList": {
+      "types": "./dist/TreeList/index.d.ts",
+      "import": "./dist/TreeList/index.js",
+      "require": "./dist/design-system-vue.umd.js"
+    },
+    "./style.css": "./dist/design-system-vue.css"
+  },
   "sideEffects": [
     "*.css"
   ],

--- a/package.json
+++ b/package.json
@@ -22,138 +22,138 @@
     "dist"
   ],
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/design-system-vue.es.js",
-      "require": "./dist/design-system-vue.umd.js"
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/design-system-vue.es.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Accordion": {
+        "types": "./dist/Accordion/index.d.ts",
+        "import": "./dist/Accordion/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./BackgroundWrapper": {
+        "types": "./dist/BackgroundWrapper/index.d.ts",
+        "import": "./dist/BackgroundWrapper/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Button": {
+        "types": "./dist/Button/index.d.ts",
+        "import": "./dist/Button/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Card": {
+        "types": "./dist/Card/index.d.ts",
+        "import": "./dist/Card/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Checkbox": {
+        "types": "./dist/Checkbox/index.d.ts",
+        "import": "./dist/Checkbox/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./DropZone": {
+        "types": "./dist/DropZone/index.d.ts",
+        "import": "./dist/DropZone/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./DropdownButton": {
+        "types": "./dist/DropdownButton/index.d.ts",
+        "import": "./dist/DropdownButton/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./GroupedButtons": {
+        "types": "./dist/GroupedButtons/index.d.ts",
+        "import": "./dist/GroupedButtons/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Header": {
+        "types": "./dist/Header/index.d.ts",
+        "import": "./dist/Header/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Icon": {
+        "types": "./dist/Icon/index.d.ts",
+        "import": "./dist/Icon/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./ImagePreview": {
+        "types": "./dist/ImagePreview/index.d.ts",
+        "import": "./dist/ImagePreview/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./LogoToteat": {
+        "types": "./dist/LogoToteat/index.d.ts",
+        "import": "./dist/LogoToteat/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Multiselect": {
+        "types": "./dist/Multiselect/index.d.ts",
+        "import": "./dist/Multiselect/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Overlay": {
+        "types": "./dist/Overlay/index.d.ts",
+        "import": "./dist/Overlay/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./OverlayMessage": {
+        "types": "./dist/OverlayMessage/index.d.ts",
+        "import": "./dist/OverlayMessage/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Radio": {
+        "types": "./dist/Radio/index.d.ts",
+        "import": "./dist/Radio/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Select": {
+        "types": "./dist/Select/index.d.ts",
+        "import": "./dist/Select/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./SkeletonPreload": {
+        "types": "./dist/SkeletonPreload/index.d.ts",
+        "import": "./dist/SkeletonPreload/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Spinner": {
+        "types": "./dist/Spinner/index.d.ts",
+        "import": "./dist/Spinner/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Tab": {
+        "types": "./dist/Tab/index.d.ts",
+        "import": "./dist/Tab/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Table": {
+        "types": "./dist/Table/index.d.ts",
+        "import": "./dist/Table/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./TextInput": {
+        "types": "./dist/TextInput/index.d.ts",
+        "import": "./dist/TextInput/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./Tooltip": {
+        "types": "./dist/Tooltip/index.d.ts",
+        "import": "./dist/Tooltip/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./TreeItem": {
+        "types": "./dist/TreeItem/index.d.ts",
+        "import": "./dist/TreeItem/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./TreeList": {
+        "types": "./dist/TreeList/index.d.ts",
+        "import": "./dist/TreeList/index.js",
+        "require": "./dist/design-system-vue.umd.js"
+      },
+      "./style.css": "./dist/design-system-vue.css"
     },
-    "./Accordion": {
-      "types": "./dist/Accordion/index.d.ts",
-      "import": "./dist/Accordion/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./BackgroundWrapper": {
-      "types": "./dist/BackgroundWrapper/index.d.ts",
-      "import": "./dist/BackgroundWrapper/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Button": {
-      "types": "./dist/Button/index.d.ts",
-      "import": "./dist/Button/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Card": {
-      "types": "./dist/Card/index.d.ts",
-      "import": "./dist/Card/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Checkbox": {
-      "types": "./dist/Checkbox/index.d.ts",
-      "import": "./dist/Checkbox/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./DropZone": {
-      "types": "./dist/DropZone/index.d.ts",
-      "import": "./dist/DropZone/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./DropdownButton": {
-      "types": "./dist/DropdownButton/index.d.ts",
-      "import": "./dist/DropdownButton/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./GroupedButtons": {
-      "types": "./dist/GroupedButtons/index.d.ts",
-      "import": "./dist/GroupedButtons/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Header": {
-      "types": "./dist/Header/index.d.ts",
-      "import": "./dist/Header/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Icon": {
-      "types": "./dist/Icon/index.d.ts",
-      "import": "./dist/Icon/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./ImagePreview": {
-      "types": "./dist/ImagePreview/index.d.ts",
-      "import": "./dist/ImagePreview/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./LogoToteat": {
-      "types": "./dist/LogoToteat/index.d.ts",
-      "import": "./dist/LogoToteat/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Multiselect": {
-      "types": "./dist/Multiselect/index.d.ts",
-      "import": "./dist/Multiselect/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Overlay": {
-      "types": "./dist/Overlay/index.d.ts",
-      "import": "./dist/Overlay/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./OverlayMessage": {
-      "types": "./dist/OverlayMessage/index.d.ts",
-      "import": "./dist/OverlayMessage/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Radio": {
-      "types": "./dist/Radio/index.d.ts",
-      "import": "./dist/Radio/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Select": {
-      "types": "./dist/Select/index.d.ts",
-      "import": "./dist/Select/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./SkeletonPreload": {
-      "types": "./dist/SkeletonPreload/index.d.ts",
-      "import": "./dist/SkeletonPreload/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Spinner": {
-      "types": "./dist/Spinner/index.d.ts",
-      "import": "./dist/Spinner/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Tab": {
-      "types": "./dist/Tab/index.d.ts",
-      "import": "./dist/Tab/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Table": {
-      "types": "./dist/Table/index.d.ts",
-      "import": "./dist/Table/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./TextInput": {
-      "types": "./dist/TextInput/index.d.ts",
-      "import": "./dist/TextInput/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./Tooltip": {
-      "types": "./dist/Tooltip/index.d.ts",
-      "import": "./dist/Tooltip/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./TreeItem": {
-      "types": "./dist/TreeItem/index.d.ts",
-      "import": "./dist/TreeItem/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./TreeList": {
-      "types": "./dist/TreeList/index.d.ts",
-      "import": "./dist/TreeList/index.js",
-      "require": "./dist/design-system-vue.umd.js"
-    },
-    "./style.css": "./dist/design-system-vue.css"
-  },
   "sideEffects": [
     "*.css"
   ],

--- a/src/components/TreeItem/TreeItem.vue
+++ b/src/components/TreeItem/TreeItem.vue
@@ -279,13 +279,14 @@ const handleDrop = (event: globalThis.DragEvent): void => {
   &.tree-item {
     --tree-item-indent: 0px;
     width: 100%;
+    background-color: var(--color-neutral);
 
     /* Striped rows - odd rows get alternate background */
     &[data-odd-row='true'] > .tree-item__content {
-      background-color: var(--color-neutral-100);
+      background-color: var(--color-neutral-50);
 
       &:hover {
-        background-color: var(--color-neutral-200);
+        background-color: var(--color-neutral-100);
       }
     }
 
@@ -362,7 +363,7 @@ const handleDrop = (event: globalThis.DragEvent): void => {
     }
 
     &[data-dragging='true'] > .tree-item__content {
-      opacity: 0.5;
+      opacity: 0.35;
     }
 
     .tree-item__drag-handle {

--- a/src/components/TreeList/__stories__/TreeList.stories.ts
+++ b/src/components/TreeList/__stories__/TreeList.stories.ts
@@ -39,6 +39,10 @@ const meta: Meta<typeof TreeList> = {
       control: 'boolean',
       description: 'Alternate row background colors (white and neutral-100)',
     },
+    bordered: {
+      control: 'boolean',
+      description: 'Show borders around tree items',
+    },
   },
 };
 


### PR DESCRIPTION
# Context

Ticket: https://github.com/toteat/trm_frontend_vue3/issues/1467

Enhance TreeItem visual styles by adjusting background colors for striped rows and dragging opacity, and add the `bordered` prop control to the TreeList stories.

**Changes include:**
- Set a neutral background color on the base `.tree-item` element
- Lighten striped row backgrounds (`neutral-100` → `neutral-50`) and their hover states (`neutral-200` → `neutral-100`)
- Reduce dragging opacity from `0.5` to `0.35` for better visual feedback
- Expose the `bordered` control in the TreeList Storybook stories

# Changes

- `src/components/TreeItem/TreeItem.vue`: 4 additions, 3 deletions
- `src/components/TreeList/__stories__/TreeList.stories.ts`: 4 additions, 0 deletions

# Evidence

https://jam.dev/c/b56fb7ad-d724-4c93-aeeb-46e1f4dc45a4