### PR TITLE
fixed PR 75 review issues

### DIFF
--- a/mcp/src/__tests__/data.test.ts
+++ b/mcp/src/__tests__/data.test.ts
@@ -105,6 +105,6 @@ describe('icons data', () => {
 
   it('ICONS_BY_CATEGORY values match ALL_ICONS', () => {
     const flatFromCategories = Object.values(ICONS_BY_CATEGORY).flat();
-    expect(flatFromCategories.length).toBe(ALL_ICONS.length);
+    expect(flatFromCategories.sort()).toEqual([...ALL_ICONS].sort());
   });
 });

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -20,6 +20,11 @@ const args = process.argv.slice(2);
 const isHttp = args.includes('--http');
 const portIndex = args.indexOf('--port');
 const parsedPort = portIndex !== -1 ? parseInt(args[portIndex + 1], 10) : 3333;
+if (portIndex !== -1 && Number.isNaN(parsedPort)) {
+  process.stderr.write(
+    `Warning: invalid --port value "${args[portIndex + 1]}", defaulting to 3333\n`,
+  );
+}
 const port = Number.isNaN(parsedPort) ? 3333 : parsedPort;
 
 if (isHttp) {
@@ -33,7 +38,22 @@ if (isHttp) {
       const chunks: Buffer[] = [];
       for await (const chunk of req) chunks.push(chunk as Buffer);
       const rawBody = Buffer.concat(chunks).toString();
-      const body = rawBody.length > 0 ? JSON.parse(rawBody) : undefined;
+
+      let body: unknown;
+      try {
+        body = rawBody.length > 0 ? JSON.parse(rawBody) : undefined;
+      } catch {
+        if (!res.headersSent) {
+          res.writeHead(400, { 'Content-Type': 'application/json' }).end(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              error: { code: -32700, message: 'Parse error: invalid JSON' },
+              id: null,
+            }),
+          );
+        }
+        return;
+      }
 
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
@@ -41,20 +61,36 @@ if (isHttp) {
       const server = createMcpServer();
       await server.connect(transport);
       await transport.handleRequest(req, res, body);
-      res.on('finish', () => server.close());
+      res.on('finish', () => {
+        Promise.resolve(server.close()).catch((err) => {
+          process.stderr.write(`MCP server close error: ${err}\n`);
+        });
+      });
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Internal server error';
+      process.stderr.write(`MCP request error: ${message}\n`);
       if (!res.headersSent) {
-        res.writeHead(400, { 'Content-Type': 'application/json' }).end(
+        res.writeHead(500, { 'Content-Type': 'application/json' }).end(
           JSON.stringify({
             jsonrpc: '2.0',
-            error: { code: -32700, message },
+            error: { code: -32603, message: 'Internal error' },
             id: null,
           }),
         );
       }
     }
+  });
+
+  httpServer.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      process.stderr.write(
+        `Port ${port} is already in use. Choose a different port with --port.\n`,
+      );
+    } else {
+      process.stderr.write(`HTTP server error: ${err.message}\n`);
+    }
+    process.exit(1);
   });
 
   httpServer.listen(port, '127.0.0.1', () => {
@@ -63,7 +99,13 @@ if (isHttp) {
     );
   });
 } else {
-  const server = createMcpServer();
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  try {
+    const server = createMcpServer();
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Failed to start MCP server (stdio): ${message}\n`);
+    process.exit(1);
+  }
 }

--- a/mcp/src/resources/index.ts
+++ b/mcp/src/resources/index.ts
@@ -47,16 +47,25 @@ export function registerResources(server: McpServer): void {
     },
     async (uri, { name }) => {
       const componentName = Array.isArray(name) ? name[0] : name;
+      if (!componentName) {
+        return {
+          contents: [
+            {
+              uri: uri.href,
+              mimeType: 'text/plain',
+              text: 'Component name is required.',
+            },
+          ],
+        };
+      }
       const component = COMPONENT_MAP.get(componentName.toLowerCase());
       if (!component) {
         return {
           contents: [
             {
               uri: uri.href,
-              mimeType: 'application/json',
-              text: JSON.stringify({
-                error: `Component "${componentName}" not found. Available: ${COMPONENTS.map((c) => c.name).join(', ')}`,
-              }),
+              mimeType: 'text/plain',
+              text: `Component "${componentName}" not found. Available: ${COMPONENTS.map((c) => c.name).join(', ')}`,
             },
           ],
         };

--- a/mcp/src/tools/index.ts
+++ b/mcp/src/tools/index.ts
@@ -10,8 +10,7 @@ export function registerTools(server: McpServer): void {
   server.registerTool(
     'list_components',
     {
-      description:
-        'List all 24 components in @toteat-eng/design-system-vue with their descriptions',
+      description: `List all ${COMPONENTS.length} components in @toteat-eng/design-system-vue with their descriptions`,
       inputSchema: {},
     },
     async () => ({
@@ -201,8 +200,7 @@ export function registerTools(server: McpServer): void {
         ? Object.entries(props)
             .map(([k, v]) => {
               const propDef = component.props.find((p) => p.name === k);
-              const isBoolean =
-                propDef?.type === 'boolean' || v === 'true' || v === 'false';
+              const isBoolean = propDef?.type === 'boolean';
               const isNumber = propDef?.type === 'number';
               if (isBoolean || isNumber) return `  :${k}="${v}"`;
               return `  ${k}="${v}"`;
@@ -216,7 +214,7 @@ export function registerTools(server: McpServer): void {
       const template =
         component.slots.length > 0 || slot
           ? `${openTag}${slotContent}${closeTag}`
-          : `${openTag.replace('>', ' />')}`;
+          : `${openTag.replace(/>$/, ' />')}`;
 
       const importPath = `@toteat-eng/design-system-vue/${name}`;
       const code = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
         "@vueuse/core": "^13.2.0",
         "axios": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",


### PR DESCRIPTION
# Context

Handling issues detected on PR 75 review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the MCP server and tooling to improve error handling and message clarity. Also fixed icon data tests and bumped `@toteat-eng/design-system-vue` to 0.1.49.

- **Bug Fixes**
  - HTTP/stdio server: validate `--port` with a warning, return JSON-RPC parse errors (-32700/400), map internal errors to 500/-32603, log to stderr, handle EADDRINUSE and exit, and safely close the server.
  - Resources: require a component name and return plain-text errors when missing or not found.
  - Tools: correct boolean prop detection and self-closing tag generation; show dynamic component count in the `list_components` description.
  - Tests: compare icon lists by values (sorted) instead of length only.

<sup>Written for commit ab29ba786fd799078cee963c33d6064fdc5c30cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

