### PR TITLE
feat: add prop type validation and allowed values hinting to MCP server

### DIFF
--- a/mcp/scripts/descriptions.json
+++ b/mcp/scripts/descriptions.json
@@ -294,7 +294,7 @@
     },
     "props": {
       "instanceName": "Unique ID (required) — used as event prefix: {instanceName}-drop, {instanceName}-drop-error, {instanceName}-remove",
-      "allowedFileTypes": "File type preset: 'images', 'documents', etc.",
+      "allowedFileTypes": "File type preset: 'images', 'text', 'video', or 'spreadsheet'",
       "accept": "MIME type filter string (e.g. 'image/*', 'application/pdf')",
       "label": "Custom label text for the drop area",
       "multiple": "Allow selecting multiple files",
@@ -368,15 +368,15 @@
     }
   },
   "LogoToteat": {
-    "description": "Toteat brand logo. Supports 'complete' (full logo with text) or 'icon-only' (isotipo) mode, with 'original' or 'white' color variants.",
+    "description": "Toteat brand logo. Supports 'complete' (full logo with text) or 'icon' (isotipo) mode, with 'original', 'cream-orange', or 'black-cream' color variants.",
     "propDefaults": {
       "mode": "'complete'",
       "variant": "'original'",
       "alt": "'Logo Toteat'"
     },
     "props": {
-      "mode": "Logo display mode: 'complete' (full logo) or 'icon-only' (isotipo)",
-      "variant": "Color variant: 'original' (brand colors) or 'white' (monochrome)",
+      "mode": "Logo display mode: 'complete' (full logo) or 'icon' (isotipo)",
+      "variant": "Color variant: 'original' (brand colors), 'cream-orange', or 'black-cream'",
       "width": "Logo width in pixels",
       "height": "Logo height in pixels",
       "alt": "Alt text for accessibility"

--- a/mcp/scripts/generate-components.ts
+++ b/mcp/scripts/generate-components.ts
@@ -73,7 +73,11 @@ export function extractAllProps(typesFile: string): Map<string, PropDef[]> {
       const typeNode = member.type;
 
       let typeStr = typeNode
-        ? checker.typeToString(checker.getTypeFromTypeNode(typeNode))
+        ? checker.typeToString(
+            checker.getTypeFromTypeNode(typeNode),
+            undefined,
+            ts.TypeFormatFlags.InTypeAlias,
+          )
         : 'unknown';
 
       typeStr = typeStr

--- a/mcp/src/data/components.ts
+++ b/mcp/src/data/components.ts
@@ -24,7 +24,11 @@ export const COMPONENTS: ComponentDef[] = [
     description:
       'Clickable button with variants, sizes, and optional icon. No default slot — use the `text` prop for the label and `iconName` for icons.',
     props: [
-      { name: 'variant', type: 'Variant', default: "'primary'" },
+      {
+        name: 'variant',
+        type: '"outline" | "outline-gray" | "primary" | "secondary" | "text" | "neutral-dark"',
+        default: "'primary'",
+      },
       { name: 'disabled', type: 'boolean', default: 'false' },
       {
         name: 'isFull',
@@ -32,7 +36,11 @@ export const COMPONENTS: ComponentDef[] = [
         default: 'false',
         description: 'Stretch to full width of parent container',
       },
-      { name: 'size', type: 'ButtonSize', default: "'medium'" },
+      {
+        name: 'size',
+        type: '"tiny" | "small" | "medium" | "large"',
+        default: "'medium'",
+      },
       { name: 'type', type: 'ButtonHTMLAttributes', default: "'button'" },
       {
         name: 'loading',
@@ -67,7 +75,7 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'groupPosition',
-        type: 'ButtonGroupPosition',
+        type: '"left" | "right" | "center" | "standalone"',
         default: "'standalone'",
         description: 'Used internally by GroupedButtons — do not set manually',
       },
@@ -151,10 +159,13 @@ export const COMPONENTS: ComponentDef[] = [
         description: 'v-model:checked — current checked state',
       },
       { name: 'disabled', type: 'boolean' },
-      { name: 'size', type: 'ComponentSize' },
+      {
+        name: 'size',
+        type: '"tiny" | "small" | "medium" | "large" | "very-large" | "very-very-large" | "ridiculously-large"',
+      },
       {
         name: 'color',
-        type: 'ThemeColor',
+        type: '"primary" | "secondary" | "neutral-300" | "primary-light" | "secondary-light" | "tertiary" | "tertiary-light" | "white" | "black" | "neutral" | "neutral-50" | "neutral-100" | ... 16 more ... | "unset"',
         description: 'Color of the checked icon (ThemeColor value)',
       },
       {
@@ -268,13 +279,16 @@ export const COMPONENTS: ComponentDef[] = [
       { name: 'disabled', type: 'boolean' },
       { name: 'readonly', type: 'boolean' },
       { name: 'required', type: 'boolean' },
-      { name: 'type', type: 'TextInputType' },
+      {
+        name: 'type',
+        type: '"number" | "text" | "password" | "email" | "search" | "tel" | "url" | "date"',
+      },
       { name: 'name', type: 'string' },
       { name: 'id', type: 'string' },
       { name: 'autocomplete', type: 'string' },
       {
         name: 'inputmode',
-        type: 'TextInputInputMode',
+        type: '"text" | "none" | "email" | "search" | "tel" | "url" | "numeric" | "decimal"',
         description:
           "Virtual keyboard hint for mobile (e.g. 'numeric', 'email')",
       },
@@ -300,11 +314,11 @@ export const COMPONENTS: ComponentDef[] = [
         description: 'Show a clear (X) button when input has a value',
       },
       { name: 'autoFocus', type: 'boolean' },
-      { name: 'size', type: 'TextInputSize' },
+      { name: 'size', type: '"small" | "medium" | "large"' },
       { name: 'fullWidth', type: 'boolean' },
       {
         name: 'validationState',
-        type: 'TextInputValidationState',
+        type: '"default" | "success" | "warning" | "error"',
         description:
           "Visual state: 'default', 'success', 'warning', or 'error'",
       },
@@ -386,12 +400,16 @@ export const COMPONENTS: ComponentDef[] = [
         description:
           'Disable client-side filtering — use for server-side search with v-model:searchQuery',
       },
-      { name: 'size', type: 'ButtonSize', default: "'medium'" },
+      {
+        name: 'size',
+        type: '"tiny" | "small" | "medium" | "large"',
+        default: "'medium'",
+      },
       { name: 'id', type: 'string' },
       { name: 'name', type: 'string' },
       {
         name: 'validationState',
-        type: 'TextInputValidationState',
+        type: '"default" | "success" | "warning" | "error"',
         description:
           "Visual state: 'default', 'success', 'warning', or 'error'",
       },
@@ -474,7 +492,11 @@ export const COMPONENTS: ComponentDef[] = [
       { name: 'searchable', type: 'boolean', default: 'true' },
       { name: 'clearable', type: 'boolean', default: 'true' },
       { name: 'closeOnSelect', type: 'boolean', default: 'false' },
-      { name: 'size', type: 'ButtonSize', default: "'medium'" },
+      {
+        name: 'size',
+        type: '"tiny" | "small" | "medium" | "large"',
+        default: "'medium'",
+      },
       { name: 'id', type: 'string' },
       { name: 'name', type: 'string' },
       { name: 'checkboxPosition', type: '"left" | "right"', default: "'left'" },
@@ -486,7 +508,7 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'validationState',
-        type: 'TextInputValidationState',
+        type: '"default" | "success" | "warning" | "error"',
         description:
           "Visual state: 'default', 'success', 'warning', or 'error'",
       },
@@ -555,9 +577,12 @@ export const COMPONENTS: ComponentDef[] = [
         type: 'string | number',
         description: 'v-model:selectedTab — the currently active tab value',
       },
-      { name: 'size', type: 'ButtonSize' },
+      { name: 'size', type: '"tiny" | "small" | "medium" | "large"' },
       { name: 'fullWidth', type: 'boolean' },
-      { name: 'selectedColor', type: 'TabSelectedColor' },
+      {
+        name: 'selectedColor',
+        type: '"primary" | "secondary" | "tertiary" | "neutral-100"',
+      },
     ],
     events: [
       { name: 'update:selectedTab', payload: 'string | number' },
@@ -594,7 +619,11 @@ export const COMPONENTS: ComponentDef[] = [
         description:
           'v-model:selectedButton — the currently active button value',
       },
-      { name: 'size', type: 'ButtonSize', default: "'medium'" },
+      {
+        name: 'size',
+        type: '"tiny" | "small" | "medium" | "large"',
+        default: "'medium'",
+      },
       { name: 'variant', type: 'ButtonVariant' },
       {
         name: 'fullWidth',
@@ -628,7 +657,11 @@ export const COMPONENTS: ComponentDef[] = [
         description:
           'Array of { value: string|number, label: string, icon?: IconNames, disabled?: boolean }',
       },
-      { name: 'size', type: 'ButtonSize', default: "'medium'" },
+      {
+        name: 'size',
+        type: '"tiny" | "small" | "medium" | "large"',
+        default: "'medium'",
+      },
       { name: 'disabled', type: 'boolean', default: 'false' },
     ],
     events: [
@@ -682,7 +715,7 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'defaultSortOrder',
-        type: 'TableSortOrder',
+        type: '"asc" | "desc"',
         default: "'asc'",
         description: "Initial sort direction: 'asc' or 'desc'",
       },
@@ -723,7 +756,7 @@ export const COMPONENTS: ComponentDef[] = [
       { name: 'disabled', type: 'boolean', default: 'false' },
       {
         name: 'size',
-        type: 'ButtonSize',
+        type: '"tiny" | "small" | "medium" | "large"',
         default: "'medium'",
         description: 'Button size variant',
       },
@@ -751,7 +784,11 @@ export const COMPONENTS: ComponentDef[] = [
         required: true,
         description: 'Tooltip text content',
       },
-      { name: 'position', type: 'TooltipPosition', default: "'top'" },
+      {
+        name: 'position',
+        type: '"left" | "right" | "top" | "bottom"',
+        default: "'top'",
+      },
       { name: 'disabled', type: 'boolean', default: 'false' },
       {
         name: 'delay',
@@ -794,7 +831,7 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'color',
-        type: 'ThemeColor',
+        type: '"primary" | "secondary" | "neutral-300" | "primary-light" | "secondary-light" | "tertiary" | "tertiary-light" | "white" | "black" | "neutral" | "neutral-50" | "neutral-100" | ... 16 more ... | "unset"',
         description: 'Icon color — accepts any ThemeColor value',
       },
     ],
@@ -808,7 +845,7 @@ export const COMPONENTS: ComponentDef[] = [
     props: [
       {
         name: 'size',
-        type: 'ComponentSize',
+        type: '"tiny" | "small" | "medium" | "large" | "very-large" | "very-very-large" | "ridiculously-large"',
         default: '1.5',
         description: 'Spinner diameter in rem units (e.g. 1.5 = 24px)',
       },
@@ -892,9 +929,10 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'allowedFileTypes',
-        type: 'AllowedFileTypes',
+        type: '"text" | "images" | "video" | "spreadsheet"',
         default: "'images'",
-        description: "File type preset: 'images', 'documents', etc.",
+        description:
+          "File type preset: 'images', 'text', 'video', or 'spreadsheet'",
       },
       {
         name: 'multiple',
@@ -992,7 +1030,7 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'placement',
-        type: 'OverlayPlacement',
+        type: '"center" | "top" | "bottom"',
         default: "'center'",
         description: 'Vertical placement of the modal content',
       },
@@ -1039,14 +1077,17 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'status',
-        type: 'OverlayMessageStatus',
+        type: '"success" | "warning" | "error" | "info"',
         description: 'Status type — determines the default icon and color',
       },
       {
         name: 'iconName',
         type: '"apple-filled" | "arrow-circle-down-outline" | "arrow-circle-left-outline" | "arrow-circle-right-outline" | "arrow-circle-up-outline" | "arrow-down-outline" | "arrow-left-outline" | ... 119 more ... | "wifi-signal-outline"',
       },
-      { name: 'iconColor', type: 'ThemeColor' },
+      {
+        name: 'iconColor',
+        type: '"primary" | "secondary" | "neutral-300" | "primary-light" | "secondary-light" | "tertiary" | "tertiary-light" | "white" | "black" | "neutral" | "neutral-50" | "neutral-100" | ... 16 more ... | "unset"',
+      },
       { name: 'iconSize', type: 'number' },
       {
         name: 'title',
@@ -1066,7 +1107,7 @@ export const COMPONENTS: ComponentDef[] = [
       { name: 'lockScroll', type: 'boolean' },
       { name: 'zIndex', type: 'number' },
       { name: 'blur', type: 'boolean' },
-      { name: 'placement', type: 'OverlayPlacement' },
+      { name: 'placement', type: '"center" | "top" | "bottom"' },
       { name: 'ariaLabel', type: 'string' },
       {
         name: 'primaryButtonLabel',
@@ -1080,13 +1121,13 @@ export const COMPONENTS: ComponentDef[] = [
       },
       {
         name: 'primaryButtonVariant',
-        type: 'Variant',
+        type: '"outline" | "outline-gray" | "primary" | "secondary" | "text" | "neutral-dark"',
         description:
           "Visual variant for the primary button (e.g. 'primary', 'secondary')",
       },
       {
         name: 'secondaryButtonVariant',
-        type: 'Variant',
+        type: '"outline" | "outline-gray" | "primary" | "secondary" | "text" | "neutral-dark"',
         description: 'Visual variant for the secondary button',
       },
       {
@@ -1152,21 +1193,21 @@ export const COMPONENTS: ComponentDef[] = [
   {
     name: 'LogoToteat',
     description:
-      "Toteat brand logo. Supports 'complete' (full logo with text) or 'icon-only' (isotipo) mode, with 'original' or 'white' color variants.",
+      "Toteat brand logo. Supports 'complete' (full logo with text) or 'icon' (isotipo) mode, with 'original', 'cream-orange', or 'black-cream' color variants.",
     props: [
       {
         name: 'mode',
-        type: 'LogoToteatMode',
+        type: '"icon" | "complete"',
         default: "'complete'",
         description:
-          "Logo display mode: 'complete' (full logo) or 'icon-only' (isotipo)",
+          "Logo display mode: 'complete' (full logo) or 'icon' (isotipo)",
       },
       {
         name: 'variant',
-        type: 'LogoToteatVariant',
+        type: '"original" | "cream-orange" | "black-cream"',
         default: "'original'",
         description:
-          "Color variant: 'original' (brand colors) or 'white' (monochrome)",
+          "Color variant: 'original' (brand colors), 'cream-orange', or 'black-cream'",
       },
       { name: 'width', type: 'number', description: 'Logo width in pixels' },
       { name: 'height', type: 'number', description: 'Logo height in pixels' },
@@ -1200,7 +1241,7 @@ export const COMPONENTS: ComponentDef[] = [
     props: [
       {
         name: 'item',
-        type: 'TreeItemData',
+        type: '{ id: string | number; label: string; children?: TreeItemData[] | undefined; disabled?: boolean | undefined; meta?: string | undefined; }',
         required: true,
         description:
           'Tree node data: { id, label, children?, disabled?, meta? }',

--- a/mcp/src/tools/index.ts
+++ b/mcp/src/tools/index.ts
@@ -5,6 +5,69 @@ import { TOKENS } from '../data/tokens.js';
 import type { TokenCategory } from '../data/tokens.js';
 import { ALL_ICONS } from '../data/icons.js';
 
+/**
+ * Maps custom type aliases to their allowed string values.
+ * Used by generate_usage to validate prop values at generation time.
+ */
+const RESOLVED_TYPES: Record<string, string[]> = {
+  Variant: [
+    'outline',
+    'outline-gray',
+    'primary',
+    'secondary',
+    'text',
+    'neutral-dark',
+  ],
+  ButtonSize: ['tiny', 'small', 'medium', 'large'],
+  ButtonVariant: [
+    'outline',
+    'outline-gray',
+    'primary',
+    'secondary',
+    'text',
+    'neutral-dark',
+  ],
+  ButtonGroupPosition: ['left', 'center', 'right', 'standalone'],
+  TextInputType: [
+    'text',
+    'password',
+    'email',
+    'search',
+    'tel',
+    'url',
+    'number',
+    'date',
+  ],
+  TextInputInputMode: [
+    'text',
+    'email',
+    'search',
+    'tel',
+    'url',
+    'none',
+    'numeric',
+    'decimal',
+  ],
+  TextInputSize: ['small', 'medium', 'large'],
+  TextInputValidationState: ['default', 'success', 'warning', 'error'],
+  LogoToteatMode: ['icon', 'complete'],
+  LogoToteatVariant: ['original', 'cream-orange', 'black-cream'],
+};
+
+/**
+ * Returns the allowed values for a prop type, or null if not a union type.
+ * Handles both RESOLVED_TYPES lookup and inline union types like '"left" | "right"'.
+ */
+function getAllowedValues(propType: string): string[] | null {
+  if (RESOLVED_TYPES[propType]) return RESOLVED_TYPES[propType];
+
+  const unionMatch = propType.match(/^"[^"]+"/);
+  if (unionMatch) {
+    return [...propType.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  }
+  return null;
+}
+
 export function registerTools(server: McpServer): void {
   // List all components
   server.registerTool(
@@ -68,8 +131,12 @@ export function registerTools(server: McpServer): void {
           const required = prop.required ? ' *(required)*' : '';
           const def = prop.default ? ` — default: \`${prop.default}\`` : '';
           const desc = prop.description ? ` — ${prop.description}` : '';
+          const allowed = getAllowedValues(prop.type);
+          const valuesHint = allowed
+            ? ` — values: ${allowed.map((a) => `\`'${a}'\``).join(', ')}`
+            : '';
           lines.push(
-            `- **${prop.name}**${required}: \`${prop.type}\`${def}${desc}`,
+            `- **${prop.name}**${required}: \`${prop.type}\`${def}${valuesHint}${desc}`,
           );
         }
         lines.push('');
@@ -196,6 +263,38 @@ export function registerTools(server: McpServer): void {
       }
 
       const name = component.name;
+
+      // Validate prop values against known types
+      if (props) {
+        const errors: string[] = [];
+        for (const [k, v] of Object.entries(props)) {
+          const propDef = component.props.find((p) => p.name === k);
+          if (!propDef) {
+            errors.push(
+              `Unknown prop "${k}" on ${name}. Available props: ${component.props.map((p) => p.name).join(', ')}`,
+            );
+            continue;
+          }
+          const allowed = getAllowedValues(propDef.type);
+          if (allowed && !allowed.includes(v)) {
+            errors.push(
+              `Invalid value "${v}" for prop "${k}" (type: ${propDef.type}). Allowed values: ${allowed.map((a) => `'${a}'`).join(', ')}`,
+            );
+          }
+        }
+        if (errors.length > 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Validation errors:\n${errors.map((e) => `- ${e}`).join('\n')}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
       const propAttrs = props
         ? Object.entries(props)
             .map(([k, v]) => {

--- a/mcp/src/tools/index.ts
+++ b/mcp/src/tools/index.ts
@@ -57,12 +57,16 @@ const RESOLVED_TYPES: Record<string, string[]> = {
 /**
  * Returns the allowed values for a prop type, or null if not a union type.
  * Handles both RESOLVED_TYPES lookup and inline union types like '"left" | "right"'.
+ * Returns null for truncated unions (containing "... N more ...") since the
+ * allow-list would be incomplete and cause false validation errors.
  */
 function getAllowedValues(propType: string): string[] | null {
   if (RESOLVED_TYPES[propType]) return RESOLVED_TYPES[propType];
 
   const unionMatch = propType.match(/^"[^"]+"/);
   if (unionMatch) {
+    // Skip truncated unions — incomplete allow-lists cause false rejections
+    if (/\.\.\.\s*\d+\s*more\s*\.\.\./.test(propType)) return null;
     return [...propType.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
   }
   return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
         "@toteat-eng/toteat-fetch": "^0.2.0",
         "@vueuse/core": "^13.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",


### PR DESCRIPTION
# Context

Improves the MCP server so that AI consumers get explicit allowed values for props instead of opaque type aliases, and validates prop values at generation time to catch mistakes early.

# Changes

- **Inline union types**: Replaced opaque aliases (`Variant`, `ButtonSize`, `TextInputType`, etc.) with literal union types (`"primary" | "secondary" | ...`) in component definitions so AI tools see valid values directly
- **Prop validation in `generate_usage`**: Added `RESOLVED_TYPES` map and `getAllowedValues()` helper to validate prop values before generating code — returns clear error messages for invalid values or unknown props
- **Allowed values hints in `get_component_detail`**: Component detail output now shows `— values: 'primary', 'secondary', ...` inline with each prop
- **TypeScript extractor fix**: Added `TypeFormatFlags.InTypeAlias` to `generate-components.ts` so the type checker expands aliases into their literal union members
- **Description fixes**: Corrected `LogoToteat` mode/variant values and `FileUpload` `allowedFileTypes` to match actual component API
- **Version bump**: 0.1.49 → 0.1.50

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds prop type validation and allowed-value hints to the MCP server to catch invalid props early and show exact values in component details. Also replaces opaque type aliases with literal unions across components and avoids false errors when unions are truncated.

- **New Features**
  - Validate prop values in `generate_usage` using `RESOLVED_TYPES` and `getAllowedValues`, with clear errors for unknown/invalid props.
  - Show allowed values per prop in `get_component_detail`.
  - Inline union types for common props (variants, sizes, input types, etc.) across Button, TextInput, Select/Multiselect, Tabs, Tooltip, Modal, LogoToteat, FileUpload, and more.

- **Refactors**
  - Expand type aliases in the extractor via `ts.TypeFormatFlags.InTypeAlias`.
  - Skip truncated unions (e.g., "... N more ...") in `getAllowedValues` to prevent false validation errors.
  - Fix `LogoToteat` mode/variant and `FileUpload.allowedFileTypes` to match the real API; bump `@toteat-eng/design-system-vue` to `0.1.49`.

<sup>Written for commit b69de6a13d1381cb1dbd21451497dc16427f1857. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

