### PR TITLE
ci mcp fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install MCP dependencies
+        run: npm ci
+        working-directory: mcp
+
       - name: Run tests with coverage
         id: coverage
         run: npm run test:coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
         "@toteat-eng/toteat-fetch": "^0.2.0",
         "@vueuse/core": "^13.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",


### PR DESCRIPTION
# Context

mcp deps configured for ci tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI by installing dependencies for the `mcp` subproject before running tests, so MCP builds and tests run reliably. Also bump `@toteat-eng/design-system-vue` to 0.1.51.

- **Bug Fixes**
  - Add `npm ci` step with `working-directory: mcp` in `.github/workflows/ci.yml`.

- **Dependencies**
  - Update `package.json` and `package-lock.json` to version 0.1.51.

<sup>Written for commit d2154a75062ef03d584e7f26698e01c8fa8e869d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

