### PR TITLE
Release v0.1.51 (#96)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install MCP dependencies
+        run: npm ci
+        working-directory: mcp
+
       - name: Run tests with coverage
         id: coverage
         run: npm run test:coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toteat-eng/design-system-vue",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
         "@toteat-eng/toteat-fetch": "^0.2.0",
         "@vueuse/core": "^13.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toteat-eng/design-system-vue",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "author": "Mauricio Antunez <mantunez@toteat.com> (https://toteat.com)",
   "description": "The Toteat Design System is a collection of components and utilities that help you build consistent and beautiful user interfaces. Build primarely to solve Toteat needs.",
   "type": "module",


### PR DESCRIPTION
* Axios removed and deps updated (#93)

* chore: replace axios with toteat-fetch, pin node lts, bump to 0.1.48

* deps updated

* feat: add prop type validation and allowed values hinting to MCP server (#82)

* feat: add prop type validation and allowed values hinting

- Introduced RESOLVED_TYPES to map custom type aliases to their allowed string values.
- Implemented getAllowedValues function to retrieve allowed values for prop types, including inline union types.
- Enhanced prop documentation in registerTools to include allowed values for each prop.
- Added validation for prop values against known types, returning errors for invalid values.

* fix: handle truncated union types in getAllowedValues function

Added a check in the getAllowedValues function to return null for truncated unions (e.g., containing "... N more ..."). This prevents incomplete allow-lists from causing false validation errors.

* chore: update version to 0.1.49 in package.json and package-lock.json

* veersion bump fixed

* ci mcp fixed (#95)

---------

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.1.51 adds MCP prop type validation with allowed values hints. It also replaces `axios` with `@toteat-eng/toteat-fetch` and fixes CI by installing MCP dependencies.

- **New Features**
  - MCP server: validate prop values against known types and show allowed values (supports inline unions and type aliases).

- **Bug Fixes**
  - Handle truncated union types to avoid false validation errors.
  - CI: install `mcp` dependencies in workflow to unblock tests.

<sup>Written for commit 6ce24830b71a97f7af15be7afaa2cbb372422668. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

